### PR TITLE
The data portion of the error object may be omitted

### DIFF
--- a/client/Request.php
+++ b/client/Request.php
@@ -86,7 +86,8 @@ class Tivoka_Request
 		if(($error = self::interpretError($resparr, $this->id)) !== FALSE) {
 			$this->error        = $error['error']['code'];
 			$this->errorMessage = $error['error']['message'];
-			$this->errorData    = $error['error']['data'];
+			if(isset($error['error']['data']))
+				$this->errorData    = $error['error']['data'];
 			return;
 		}
 	


### PR DESCRIPTION
For further details: http://www.jsonrpc.org/specification#error_object

I know this is pretty small, but is annoying when you have php.ini set to show any errors, aka development ;)
