### PR TITLE
new: headers are now stored, and 'Set-Cookie' is honored.

### DIFF
--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -84,9 +84,10 @@ class Request
      * @param string $response json data
      * @return void
      */
-    public function setResponse($response) {
+    public function setResponse($response, $headers=NULL) {
         $this->response = $response;
-    
+        $this->responseHeaders = $headers;
+
         //no response?
         if(trim($response) == '') {
             throw new Exception\ConnectionException('No response received');


### PR DESCRIPTION
Hello, set-cookies, take 2:

Could you consider merging this commit if this seems appropriate to you ? I could'nt use Tivoka without honoring the Set-Cookie pattern in my use of this library. It contains:
- an extraction part to get Set-Cookie header from server, 
- and a part to set header "Cookie" with the previous saved cookie.

Thank you, and sorry for the previous bogus pull request.

Happy Coding,
Valentin Lab
