### PR TITLE
Storing response headers and setting request headers

### DIFF
--- a/lib/Tivoka/Client/BatchRequest.php
+++ b/lib/Tivoka/Client/BatchRequest.php
@@ -126,5 +126,23 @@ class BatchRequest extends Request
             $requests[ $req->id ]->setResponse(json_encode($resp));
         }       
     }
+
+    /**
+     * Save and parse the HTTP headers
+     * @param array $raw_headers array of string coming from $http_response_header magic var
+     * @return void
+     */
+    public function setHeaders($raw_headers) {
+
+      parent::setHeaders($raw_headers);
+
+      $requests = $this->id;
+      foreach($requests as $req) {
+        $requests[ $req->id ]->responseHeadersRaw = $raw_headers;
+        $requests[ $req->id ]->responseHeaders = $this->responseHeaders;
+      }
+    }
+
+
 }
 ?>

--- a/lib/Tivoka/Client/Connection.php
+++ b/lib/Tivoka/Client/Connection.php
@@ -112,8 +112,8 @@ class Connection {
         if($response === FALSE) {
             throw new Exception\ConnectionException('Connection to "'.$this->target.'" failed');
         }
-        $request->setHeaders($http_response_header);
         $request->setResponse($response);
+        $request->setHeaders($http_response_header);
         return $request;
     }
     

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -48,7 +48,10 @@ class Request
     public $error;
     public $errorMessage;
     public $errorData;
-    
+
+    public $responseHeaders;
+    public $responseHeadersRaw;
+
     /**
      * Constructs a new JSON-RPC request object
      * @param string $method The remote procedure to invoke


### PR DESCRIPTION
Hi,

This is the followup of my previous pull request concerning the Set-Cookie mecanism.

Unfortunately, following correctly Set-Cookie mecanism is a lot of hassle and require parsing the Set-Cookie line(s) and check cookie paths and expiration times (cf: http://tools.ietf.org/html/rfc6265#section-4.1.2). I know I won't need that much coding with my current needs.

But nevertheless, this code is what I can contribute for now: a small functionality allowing to access the response headers and setting the request headers. This would allow me (and hopefully other people) to use tivoka in environment that need some headers fiddling (as Cookie management would require for example).

I'm not sure to reach your developpment standards but did my best ;). Any comments are welcome.

Valentin Lab
