### PR TITLE
fix: json-rpc result can be ``null`` and should not trigger an exception...

### DIFF
--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -143,7 +143,8 @@ class Request
     {
         switch($spec) {
             case Tivoka::SPEC_2_0:
-                if(isset($assoc['jsonrpc'], $assoc['result'], $assoc['id']) === FALSE) return FALSE;
+                if(isset($assoc['jsonrpc'], $assoc['id']) === FALSE || 
+                   !array_key_exists('result', $assoc)) return FALSE;
                 if($assoc['id'] !== $id || $assoc['jsonrpc'] != '2.0') return FALSE;
                 return array(
                         'id' => $assoc['id'],


### PR DESCRIPTION
Hi,

The json-rpc server I'm dealing with (OpenERP) returns 'null' as a normal error-free response to a json-rpc call. And this triggers an error in tivoka at result interpretation time. (Request::interpretResult() )

It seems it's also a difference between JSON RPC 1.0 and 2.0 (http://www.jsonrpc.org/specification)

I've corrected this behavior by my own means. I hope this is not too crappy. 

Many thanks for tivoka, again...

Valentin Lab
