### PR TITLE
JSON encoder abstraction.

### DIFF
--- a/lib/Tivoka/Client.php
+++ b/lib/Tivoka/Client.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tivoka - JSON-RPC done right!
- * Copyright (c) 2011-2012 by Marcel Klehr <mklehr@gmx.net>
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
  *
  * MIT LICENSE
  *
@@ -26,10 +26,12 @@
  * @package  Tivoka
  * @author Marcel Klehr <mklehr@gmx.net>
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
- * @copyright (c) 2011-2012, Marcel Klehr
+ * @copyright (c) 2011-2013, Marcel Klehr
  */
 
 namespace Tivoka;
+
+use Tivoka\Encoder\EncoderInterface;
 
 /**
  * The public interface to all tivoka functions
@@ -41,10 +43,11 @@ abstract class Client
     /**
      * Initializes a Connection to a remote server
      * @param mixed $target Remote end-point definition
+     * @param EncoderInterface $encoder JSON encoder/decoder.
      * @return Tivoka\Client\Connection\ConnectionInterface
      */
-    public static function connect($target) {
-        return Client\Connection\AbstractConnection::factory($target);
+    public static function connect($target, EncoderInterface $encoder = null) {
+        return Client\Connection\AbstractConnection::factory($target, $encoder);
     }
     
     /**

--- a/lib/Tivoka/Client/Connection/ConnectionInterface.php
+++ b/lib/Tivoka/Client/Connection/ConnectionInterface.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tivoka - JSON-RPC done right!
- * Copyright (c) 2011-2012 by Marcel Klehr <mklehr@gmx.net>
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
  *
  * MIT LICENSE
  *
@@ -26,12 +26,13 @@
  * @package  Tivoka
  * @author Marcel Klehr <mklehr@gmx.net>
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
- * @copyright (c) 2011-2012, Marcel Klehr
+ * @copyright (c) 2011-2013, Marcel Klehr
  */
 
 namespace Tivoka\Client\Connection;
 
 use Tivoka\Client\Request;
+use Tivoka\Encoder\EncoderInterface;
 
 /**
  * Connection interface
@@ -70,4 +71,11 @@ interface ConnectionInterface {
      * @return Tivoka\Client\NativeInterface
      */
     public function getNativeInterface();
+
+    /**
+     * Sets JSON encoder for this connection.
+     * @param EncoderInterface $encoder JSON encoder/decoder.
+     * @return ConnectionInterface Self instance.
+     */
+    public function setEncoder(EncoderInterface $encoder);
 }

--- a/lib/Tivoka/Client/Connection/Http.php
+++ b/lib/Tivoka/Client/Connection/Http.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tivoka - JSON-RPC done right!
- * Copyright (c) 2011-2012 by Marcel Klehr <mklehr@gmx.net>
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
  *
  * MIT LICENSE
  *
@@ -26,11 +26,12 @@
  * @package  Tivoka
  * @author Marcel Klehr <mklehr@gmx.net>
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
- * @copyright (c) 2011-2012, Marcel Klehr
+ * @copyright (c) 2011-2013, Marcel Klehr
  */
 
 namespace Tivoka\Client\Connection;
 use Tivoka\Client\BatchRequest;
+use Tivoka\Encoder\EncoderInterface;
 use Tivoka\Exception;
 use Tivoka\Client\Request;
 
@@ -47,8 +48,9 @@ class Http extends AbstractConnection {
      * Constructs connection
      * @access private
      * @param string $target URL
+     * @param EncoderInterface $encoder JSON encoder/decoder.
      */
-    public function __construct($target) {
+    public function __construct($target, EncoderInterface $encoder = null) {
         //validate url...
         if (!filter_var($target, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
             throw new Exception\Exception('Valid URL (scheme://domain[/path][/file]) required.');
@@ -61,6 +63,8 @@ class Http extends AbstractConnection {
         }
 
         $this->target = $target;
+
+        parent::__construct($encoder);
     }
 
     /**
@@ -90,7 +94,7 @@ class Http extends AbstractConnection {
         // preparing connection...
         $context = array(
                 'http' => array(
-                    'content' => $request->getRequest($this->spec),
+                    'content' => $request->getRequest($this->spec, $this->encoder),
                     'header' => "Content-Type: application/json\r\n".
                                 "Connection: Close\r\n",
                     'method' => 'POST',
@@ -105,7 +109,7 @@ class Http extends AbstractConnection {
         if($response === FALSE) {
             throw new Exception\ConnectionException('Connection to "'.$this->target.'" failed');
         }
-        $request->setResponse($response);
+        $request->setResponse($response, $this->encoder);
         $request->setHeaders($http_response_header);
         return $request;
     }

--- a/lib/Tivoka/Client/Connection/Tcp.php
+++ b/lib/Tivoka/Client/Connection/Tcp.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tivoka - JSON-RPC done right!
- * Copyright (c) 2011-2012 by Marcel Klehr <mklehr@gmx.net>
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
  *
  * MIT LICENSE
  *
@@ -26,11 +26,12 @@
  * @package  Tivoka
  * @author Marcel Klehr <mklehr@gmx.net>
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
- * @copyright (c) 2011-2012, Marcel Klehr
+ * @copyright (c) 2011-2013, Marcel Klehr
  */
 
 namespace Tivoka\Client\Connection;
 use Tivoka\Client\BatchRequest;
+use Tivoka\Encoder\EncoderInterface;
 use Tivoka\Exception;
 use Tivoka\Client\Request;
 
@@ -63,8 +64,9 @@ class Tcp extends AbstractConnection {
      * Constructs connection.
      * @param string $host Server host.
      * @param int $port Server port.
+     * @param EncoderInterface $encoder JSON encoder/decoder.
      */
-    public function __construct($host, $port)
+    public function __construct($host, $port, EncoderInterface $encoder = null)
     {
         //validate url...
         if (!is_numeric($port)) {
@@ -73,6 +75,8 @@ class Tcp extends AbstractConnection {
 
         $this->host = $host;
         $this->port = $port;
+
+        parent::__construct($encoder);
     }
 
     /**
@@ -133,7 +137,7 @@ class Tcp extends AbstractConnection {
         }
 
         // sending request
-        fwrite($this->socket, $request->getRequest($this->spec));
+        fwrite($this->socket, $request->getRequest($this->spec, $this->encoder));
         fwrite($this->socket, "\n");
         fflush($this->socket);
 
@@ -144,7 +148,7 @@ class Tcp extends AbstractConnection {
             throw new Exception\ConnectionException('Connection to "' . $this->host . ':' . $this->port . '" failed');
         }
 
-        $request->setResponse($response);
+        $request->setResponse($response, $this->encoder);
         return $request;
     }
 }

--- a/lib/Tivoka/Encoder/EncoderInterface.php
+++ b/lib/Tivoka/Encoder/EncoderInterface.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tivoka - JSON-RPC done right!
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package  Tivoka
+ * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
+ * @copyright (c) 2013, Marcel Klehr
+ */
+
+namespace Tivoka\Encoder;
+
+/**
+ * JSON encoder interface.
+ * @package Tivoka
+ */
+interface EncoderInterface
+{
+    /**
+     * Encodes data to JSON.
+     *
+     * @param mixed $data Any serializable data.
+     * @return string JSON string.
+     * @throws EncoderException When serialization fails.
+     */
+    public function encode($data);
+
+    /**
+     * Decodes JSON to data.
+     *
+     * @param string $json JSON string.
+     * @return mixed Unserialized data.
+     * @throws EncoderException When serialization fails.
+     */
+    public function decode($json);
+}

--- a/lib/Tivoka/Encoder/Exception/EncoderException.php
+++ b/lib/Tivoka/Encoder/Exception/EncoderException.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Tivoka - JSON-RPC done right!
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package  Tivoka
+ * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
+ * @copyright (c) 2013, Marcel Klehr
+ */
+
+namespace Tivoka\Encoder\Exception;
+
+use RuntimeException;
+
+/**
+ * JSON (un)serialization handling exception.
+ * @package Tivoka
+ */
+class EncoderException extends RuntimeException
+{
+}

--- a/lib/Tivoka/Encoder/JsonEncoder.php
+++ b/lib/Tivoka/Encoder/JsonEncoder.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tivoka - JSON-RPC done right!
+ * Copyright (c) 2011-2013 by Marcel Klehr <mklehr@gmx.net>
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package  Tivoka
+ * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
+ * @copyright (c) 2013, Marcel Klehr
+ */
+
+namespace Tivoka\Encoder;
+
+use Tivoka\Encoder\Exception\EncoderException;
+
+/**
+ * Simple JSON encoder/decoder handling.
+ * @package Tivoka
+ */
+class JsonEncoder implements EncoderInterface
+{
+    /**
+     * List of known JSON serialization errors.
+     * @var string[]
+     */
+    protected static $json_errors = array(
+        JSON_ERROR_NONE => '',
+        JSON_ERROR_DEPTH => 'The maximum stack depth has been exceeded',
+        JSON_ERROR_CTRL_CHAR => 'Control character error, possibly incorrectly encoded',
+        JSON_ERROR_SYNTAX => 'Syntax error',
+    );
+
+    /**
+     * Encodes data to JSON.
+     *
+     * @param mixed $data Any serializable data.
+     * @return string JSON string.
+     * @throws EncoderException When serialization fails.
+     */
+    public function encode($data)
+    {
+        $json = json_encode($data);
+
+        if (!is_string($json)) {
+            throw new EncoderException(
+                'Could not encode data of type ' .
+                (is_object($data) ? get_class($data) : gettype($data)) .
+                ' to JSON: ' .
+                static::$json_errors[json_last_error()]
+            );
+        }
+
+        return $json;
+    }
+
+    /**
+     * Decodes JSON to data.
+     *
+     * @param string $json JSON string.
+     * @return mixed Unserialized data.
+     * @throws EncoderException When serialization fails.
+     */
+    public function decode($json)
+    {
+        $data = json_decode($json, true);
+
+        if (null === $data) {
+            throw new EncoderException('JSON parse error: ' . static::$json_errors[json_last_error()]);
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
This is just a first draft - when will pass review, I can write documentation for that.

It's a response to #33 - of course it doesn't provide a solution for case in that issue, but it allows developer to write own handler (handling different encodings with `json_encode()`/`json_decode()` could be done just as sub-class of `JsonEncoder`).

Other use case - one could use `Zend\Json\Json` encoder or `JMSSerializer` to handle more advanced data processing.
