### PR TITLE
main classes changed to be not abstract

### DIFF
--- a/lib/Tivoka/Client.php
+++ b/lib/Tivoka/Client.php
@@ -35,7 +35,7 @@ namespace Tivoka;
  * The public interface to all tivoka functions
  * @package Tivoka
  */
-abstract class Client
+class Client
 {
     
     /**

--- a/lib/Tivoka/Server.php
+++ b/lib/Tivoka/Server.php
@@ -34,7 +34,7 @@ namespace Tivoka;
  * The public interface on the server-side 
  * @package Tivoka
  */
-abstract class Server
+class Server
 {
     
     /**

--- a/lib/Tivoka/Tivoka.php
+++ b/lib/Tivoka/Tivoka.php
@@ -34,7 +34,7 @@ namespace Tivoka;
  * The public interface to all tivoka functions
  * @package Tivoka
  */
-abstract class Tivoka
+class Tivoka
 {
     const SPEC_1_0 = 8;             // 000 001 000
     const SPEC_2_0 = 16;            // 000 010 000


### PR DESCRIPTION
is there a special reason that you declare the main classes (Client, Server and Tivoka) as abstract? according your manual these classes have to be used directly. 

if declace them as abstract, the classes cannot be instanciated:
`Fatal error: Cannot instantiate abstract class Tivoka\Client`

this prevents it from beeing easily used in the [dependency injection container](http://symfony.com/doc/current/book/service_container.html) as [factory class](http://symfony.com/doc/current/components/dependency_injection/factories.html#passing-arguments-to-the-factory-method) in the [symfony](http://symfony.com) framework.
