### PR TITLE
Adding possibility to set websocket options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "textalk/websocket": "0.1.1"
+        "textalk/websocket": "1.0.*"
     },
     "autoload": {
         "psr-0" : {

--- a/lib/Tivoka/Client/Connection/WebSocket.php
+++ b/lib/Tivoka/Client/Connection/WebSocket.php
@@ -24,11 +24,19 @@ class WebSocket extends AbstractConnection {
      *
      * @param string $host Server host.
      * @param int $port Server port.
+     * @param array $options
+     *   Associative array containing:
+     *   - headers:  Request headers to add/override.
+     *   - timeout:  Socket connect and wait timeout in seconds.
      */
-    public function __construct($url)
+    public function __construct($url, $options = array())
     {
         $this->url       = $url;
-        $this->ws_client = new Client($url, array('timeout' => $this->timeout));
+
+        if (isset($options['timeout'])) $this->timeout = $options['timeout'];
+        else $options['timeout'] = $this->timeout;
+
+        $this->ws_client = new Client($url, $options);
     }
 
     /**


### PR DESCRIPTION
This makes it possible to set websocket request headers and other options.

To do it you have to explicitly instantiate a Tivoka\Client\Connection\WebSocket, I chose not to implement it in the connection factory since you must already know that it is a websocket.

I'd be greatful for a version bump after this, since I have packages depending on it (and not immediately removing the branch, since my package today specs dependency on dev-dev-websocket-options).
