### PR TITLE
Provide SSL verification toggle for HTTP(S) connections.

### DIFF
--- a/lib/Tivoka/Client/Connection/AbstractConnection.php
+++ b/lib/Tivoka/Client/Connection/AbstractConnection.php
@@ -54,6 +54,12 @@ abstract class AbstractConnection implements ConnectionInterface {
      */
     protected $timeout = self::DEFAULT_TIMEOUT;
 
+    /**
+     * Connections options.
+     * @var array
+     */
+    protected $options = array();
+
     public $spec = Tivoka::SPEC_2_0;
 
     /**
@@ -62,6 +68,16 @@ abstract class AbstractConnection implements ConnectionInterface {
      */
     public function useSpec($spec) {
         $this->spec = Tivoka::validateSpecVersion($spec);
+        return $this;
+    }
+
+    /**
+     * Changes connection options.
+     * @param array $options
+     * @return Self reference.
+     */
+    public function setOptions($options) {
+        $this->options = $options;
         return $this;
     }
 

--- a/lib/Tivoka/Client/Connection/ConnectionInterface.php
+++ b/lib/Tivoka/Client/Connection/ConnectionInterface.php
@@ -45,6 +45,12 @@ interface ConnectionInterface {
     public function useSpec($spec);
 
     /**
+     * Sets any backend-specific options for this connection
+     * @param string $options The backend-specific options.
+     */
+    public function setOptions($options);
+
+    /**
      * Sends a JSON-RPC request
      * @param Request $request A Tivoka request
      * @return Request if sent as a batch request the BatchRequest object will be returned

--- a/lib/Tivoka/Client/Connection/Http.php
+++ b/lib/Tivoka/Client/Connection/Http.php
@@ -42,6 +42,7 @@ class Http extends AbstractConnection {
 
     public $target;
     public $headers = array();
+    public $options = array();
 
     /**
      * Constructs connection
@@ -61,6 +62,16 @@ class Http extends AbstractConnection {
         }
 
         $this->target = $target;
+    }
+
+    /**
+     * Changes connection options.
+     * @param array $options
+     * @return Self reference.
+     */
+    public function setOptions($options) {
+        $this->options = $options;
+        return $this;
     }
 
     /**
@@ -111,6 +122,9 @@ class Http extends AbstractConnection {
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->timeout);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLOPT_HEADERFUNCTION, $headerFunction);
+            if (isset($this->options['ssl_verify_peer'])) {
+                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->options['ssl_verify_peer']);
+            }
             $response = @curl_exec($ch);
             curl_close($ch);
         } elseif (ini_get('allow_url_fopen')) {
@@ -124,6 +138,9 @@ class Http extends AbstractConnection {
                         'timeout' => $this->timeout
                     )
             );
+            if (isset($this->options['ssl_verify_peer'])) {
+                $context['ssl']['verify_peer'] = $this->options['ssl_verify_peer'];
+            }
             foreach($this->headers as $label => $value) {
             $context['http']['header'] .= $label . ": " . $value . "\r\n";
             }

--- a/lib/Tivoka/Client/Connection/Http.php
+++ b/lib/Tivoka/Client/Connection/Http.php
@@ -42,7 +42,6 @@ class Http extends AbstractConnection {
 
     public $target;
     public $headers = array();
-    public $options = array();
 
     /**
      * Constructs connection
@@ -62,16 +61,6 @@ class Http extends AbstractConnection {
         }
 
         $this->target = $target;
-    }
-
-    /**
-     * Changes connection options.
-     * @param array $options
-     * @return Self reference.
-     */
-    public function setOptions($options) {
-        $this->options = $options;
-        return $this;
     }
 
     /**


### PR DESCRIPTION
This patch provides:

* The ability to set an array of opaque "options" on the HTTP connection; and,
* The ability to toggle the SSL verification behavior of the HTTP connection.

Let me know if I need to make any other modifications.

