### PR TITLE
Added default values for error.error and error.message

### DIFF
--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -140,8 +140,8 @@ class Request
     public function interpretResponse($json_struct) {
         //server error?
         if(($error = self::interpretError($this->spec, $json_struct, $this->id)) !== FALSE) {
-            $this->error        = $error['error']['code'];
-            $this->errorMessage = $error['error']['message'];
+            $this->error        = (isset($error['error']['error'])) ? $error['error']['code'] : 'error';
+            $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
             $this->errorData    = (isset($error['error']['data'])) ? $error['error']['data'] : null;
             return;
         }

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -140,8 +140,13 @@ class Request
     public function interpretResponse($json_struct) {
         //server error?
         if(($error = self::interpretError($this->spec, $json_struct, $this->id)) !== FALSE) {
-            $this->error        = (isset($error['error']['error'])) ? $error['error']['code'] : 'error';
-            $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
+            if($this->spec == Tivoka::SPEC_1_0) {
+                $this->error        = (isset($error['error']['code'])) ? $error['error']['code'] : 'error';
+                $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
+            } else {
+                $this->error        = $error['error']['code'];
+                $this->errorMessage = $error['error']['message'];
+            }
             $this->errorData    = (isset($error['error']['data'])) ? $error['error']['data'] : null;
             return;
         }


### PR DESCRIPTION
When tivoka used with http://golang.org/pkg/net/rpc/jsonrpc/ there is no "error" or "message" in server response, so we get and undefined index exception. Fixed it by providing some default values.