### PR TITLE
Null response

### DIFF
--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -188,8 +188,10 @@ class Request
                         'result' => $assoc['result']
                 );
             case Tivoka::SPEC_1_0:
-                if(isset($assoc['result'], $assoc['id']) === FALSE) return FALSE;
-                if($assoc['id'] !== $id && $assoc['result'] === null) return FALSE;
+                if(!array_key_exists('result', $assoc))
+                    return FALSE;
+                if(!isset($assoc['id']) || $assoc['id'] !== $id)
+                     return FALSE;
                 return array(
                     'id' => $assoc['id'],
                     'result' => $assoc['result']

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -140,8 +140,8 @@ class Request
     public function interpretResponse($json_struct) {
         //server error?
         if(($error = self::interpretError($this->spec, $json_struct, $this->id)) !== FALSE) {
-            $this->error        = $error['error']['code'];
-            $this->errorMessage = $error['error']['message'];
+            $this->error        = (isset($error['error']['error'])) ? $error['error']['code'] : 'error';
+            $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
             $this->errorData    = (isset($error['error']['data'])) ? $error['error']['data'] : null;
             return;
         }

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -140,8 +140,13 @@ class Request
     public function interpretResponse($json_struct) {
         //server error?
         if(($error = self::interpretError($this->spec, $json_struct, $this->id)) !== FALSE) {
-            $this->error        = (isset($error['error']['error'])) ? $error['error']['code'] : 'error';
-            $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
+            if($this->spec == Tivoka::SPEC_1_0) {
+                $this->error        = (isset($error['error']['code'])) ? $error['error']['code'] : 'error';
+                $this->errorMessage = (isset($error['error']['message'])) ? $error['error']['message'] : 'no message provided; see errorData';
+            } else {
+                $this->error        = $error['error']['code'];
+                $this->errorMessage = $error['error']['message'];
+            }
             $this->errorData    = (isset($error['error']['data'])) ? $error['error']['data'] : null;
             return;
         }


### PR DESCRIPTION
When response.result value is present in server's response, but it's value is null tivoka yells at me: "Invalid response structure".
Specs says about result:
2.0: "The value of this member is determined by the method invoked on the Server."
1.0: "The Object that was returned by the invoked method. This must be null in case there was an error invoking the method."
So none of them tells that null is an invalid value.
In go language empty list is null, so I cannot simply send one.
Also no result is okay especially in unix world ;)