### PR TITLE
Initialize cURL only once and support cookies

### DIFF
--- a/lib/Tivoka/Client/Connection/Http.php
+++ b/lib/Tivoka/Client/Connection/Http.php
@@ -80,6 +80,7 @@ class Http extends AbstractConnection {
             curl_setopt($this->ch, CURLOPT_POST, true);
             curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, $this->timeout);
             curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($this->ch, CURLOPT_COOKIEFILE, true);
         }
     }
 


### PR DESCRIPTION
This initializes cURL only once and enables it cookiefile options, supporting cookies to be used. 