### PR TITLE
Fix interpret error notices

### DIFF
--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -224,7 +224,7 @@ class Request
                     'id' => $assoc['id'],
                     'error' => array(
                         'data' => $assoc['error'],
-                        'code' => null,
+                        'code' => $assoc['error'],
                         'message' => $assoc['error']
                     )
                 );

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -226,7 +226,7 @@ class Request
                         'data' => $assoc['error'],
                         'code' => null,
                         'message' => $assoc['error']
-                  )
+                    )
                 );
         }
     }

--- a/lib/Tivoka/Client/Request.php
+++ b/lib/Tivoka/Client/Request.php
@@ -222,7 +222,11 @@ class Request
                 if(isset($assoc['error']) === FALSE) return FALSE;
                 return array(
                     'id' => $assoc['id'],
-                    'error' => array('data' => $assoc['error'])
+                    'error' => array(
+                        'data' => $assoc['error'],
+                        'code' => null,
+                        'message' => $assoc['error']
+                  )
                 );
         }
     }


### PR DESCRIPTION
When interpreting the response in Request.php, it expected the interpretError method to return an error associative array with 'code' and 'message' keys alongside the existing 'data' key. This adds those two to resolve PHP notices thrown.

This is for the 1.0 spec.